### PR TITLE
TASK: Update category-change on move of posts

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -24,6 +24,12 @@ class Package extends BasePackage
         );
         $dispatcher->connect(
             'Neos\ContentRepository\Domain\Model\Node',
+            'beforeNodeMove',
+            'Breadlesscode\Blog\Service\PostNodePreparationService',
+            'beforeNodeMoved'
+        );
+        $dispatcher->connect(
+            'Neos\ContentRepository\Domain\Model\Node',
             'afterNodeMove',
             'Breadlesscode\Blog\Service\PostNodePreparationService',
             'afterNodeMoved'


### PR DESCRIPTION
This change updates the way categories are set for posts when they get moved. 
On moving a post it now removes the category of the current (old) parent node (if it is a category page) and adds the category of the new parent (category) node, but keeps the other categories of the post node as set by the user.

An other solution could be, to keep all categories, if there is more than one/the current parent and only add the new category/parent, if it is not already in the list of categories.